### PR TITLE
set correct order status after failed cancel request

### DIFF
--- a/flumine/execution/betfairexecution.py
+++ b/flumine/execution/betfairexecution.py
@@ -76,7 +76,10 @@ class BetfairExecution(BaseExecution):
                         else:
                             order.executable()
                     elif instruction_report.status == "FAILURE":
-                        order.executable()
+                        if instruction_report.error_code == "BET_TAKEN_OR_LAPSED":
+                            order.execution_complete()
+                        else:
+                            order.executable()
                         failed_transaction_count += 1
                     elif instruction_report.status == "TIMEOUT":
                         order.executable()

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -473,6 +473,7 @@ class BetfairExecutionTest(unittest.TestCase):
         mock_report = mock.Mock()
         mock_instruction_report = mock.Mock()
         mock_instruction_report.status = "FAILURE"
+        mock_instruction_report.error_code = "SOME_BETFAIR_CANCEL_ERROR_CODE"
         mock_instruction_report.instruction.bet_id = 123
         mock_report.cancel_instruction_reports = [mock_instruction_report]
         mock__execution_helper.return_value = mock_report
@@ -484,6 +485,39 @@ class BetfairExecutionTest(unittest.TestCase):
             mock_order, mock_instruction_report, OrderPackageType.CANCEL
         )
         mock_order.executable.assert_called_with()
+        mock_order.trade.__enter__.assert_called_with()
+        mock_order.trade.__exit__.assert_called_with(None, None, None)
+        mock_order_package.client.add_transaction.assert_called_with(1, failed=True)
+
+    @mock.patch("flumine.execution.betfairexecution.BetfairExecution._order_logger")
+    @mock.patch("flumine.execution.betfairexecution.BetfairExecution.cancel")
+    @mock.patch("flumine.execution.betfairexecution.BetfairExecution._execution_helper")
+    def test_execute_cancel_failure_bet_taken_or_lapsed(
+        self, mock__execution_helper, mock_cancel, mock__order_logger
+    ):
+        mock_session = mock.Mock()
+        mock_order = mock.Mock()
+        mock_order.trade.__enter__ = mock.Mock()
+        mock_order.trade.__exit__ = mock.Mock()
+        mock_order.bet_id = 123
+        mock_order_package = mock.Mock()
+        mock_order_package.__iter__ = mock.Mock(return_value=iter([mock_order]))
+        mock_order_package.info = {}
+        mock_report = mock.Mock()
+        mock_instruction_report = mock.Mock()
+        mock_instruction_report.status = "FAILURE"
+        mock_instruction_report.error_code = "BET_TAKEN_OR_LAPSED"
+        mock_instruction_report.instruction.bet_id = 123
+        mock_report.cancel_instruction_reports = [mock_instruction_report]
+        mock__execution_helper.return_value = mock_report
+        self.execution.execute_cancel(mock_order_package, mock_session)
+        mock__execution_helper.assert_called_with(
+            mock_cancel, mock_order_package, mock_session
+        )
+        mock__order_logger.assert_called_with(
+            mock_order, mock_instruction_report, OrderPackageType.CANCEL
+        )
+        mock_order.execution_complete.assert_called_with()
         mock_order.trade.__enter__.assert_called_with()
         mock_order.trade.__exit__.assert_called_with(None, None, None)
         mock_order_package.client.add_transaction.assert_called_with(1, failed=True)


### PR DESCRIPTION
If cancelling an order fails with the error `BET_TAKEN_OR_LAPSED`, the order should be marked as `execution_complete`, not `executable`.