### PR TITLE
close #480

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Release History
 1.19.11 (2021-08-26)
 +++++++++++++++++++
 
+**Improvements**
+
+- #480 Correctly simulate ClearedMarket event when backtesting/paper trading
+
 **Libraries**
 
 - betfairlightweight upgraded to 2.13.2

--- a/examples/controls/backtestloggingcontrol.py
+++ b/examples/controls/backtestloggingcontrol.py
@@ -68,3 +68,16 @@ class BacktestLoggingControl(LoggingControl):
                     )
 
         logger.info("Orders updated", extra={"order_count": len(orders)})
+
+    def _process_cleared_markets(self, event):
+        cleared_markets = event.event
+        for cleared_market in cleared_markets.orders:
+            logger.info(
+                "Cleared market",
+                extra={
+                    "market_id": cleared_market.market_id,
+                    "bet_count": cleared_market.bet_count,
+                    "profit": cleared_market.profit,
+                    "commission": cleared_market.commission,
+                },
+            )

--- a/flumine/markets/market.py
+++ b/flumine/markets/market.py
@@ -174,6 +174,23 @@ class Market:
         elif self.market_book:
             return self.market_book.market_definition.race_type
 
+    def cleared(self, commission: float) -> dict:
+        orders = [order for order in self.blotter if order.size_matched]
+        profit = round(sum([order.simulated.profit for order in orders]), 2)
+        return {
+            "marketId": self.market_id,
+            "eventId": self.event_id,
+            "eventTypeId": self.event_type_id,
+            "customerStrategyRef": config.hostname,
+            "lastMatchedDate": None,
+            "placedDate": None,
+            "settledDate": None,
+            "betCount": len(orders),
+            "betOutcome": "WON" if profit >= 0 else "LOST",
+            "commission": round(max(profit * commission, 0), 2),
+            "profit": profit,
+        }
+
     @property
     def info(self) -> dict:
         return {

--- a/flumine/worker.py
+++ b/flumine/worker.py
@@ -249,7 +249,6 @@ def _get_cleared_market(flumine, betting_client, market_id: str) -> bool:
 
     if cleared_markets.orders:
         flumine.handler_queue.put(events.ClearedMarketsEvent(cleared_markets))
-        flumine.log_control(events.ClearedMarketsEvent(cleared_markets))
         return True
     else:
         return False

--- a/tests/test_fluminebacktest.py
+++ b/tests/test_fluminebacktest.py
@@ -244,6 +244,7 @@ class FlumineBacktestTest(unittest.TestCase):
         mock_market = mock.Mock(closed=False, elapsed_seconds_closed=None)
         mock_market.market_book.streaming_unique_id = 2
         mock_market.blotter.process_cleared_orders.return_value = []
+        mock_market.cleared.return_value = {}
         self.flumine.markets._markets = {
             "1.23": mock_market,
             "4.56": mock.Mock(market_id="4.56", closed=True, elapsed_seconds_closed=25),

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from flumine.markets.markets import Markets
 from flumine.markets.market import Market
+from flumine import config
 
 
 class MarketsTest(unittest.TestCase):
@@ -316,6 +317,26 @@ class MarketTest(unittest.TestCase):
         self.market.market_book = mock_market_book
         self.assertEqual(
             self.market.race_type, mock_market_book.market_definition.race_type
+        )
+
+    @mock.patch("flumine.markets.market.Market.event_type_id")
+    @mock.patch("flumine.markets.market.Market.event_id")
+    def test_cleared(self, mock_event_id, mock_event_type_id):
+        self.assertEqual(
+            self.market.cleared(0.05),
+            {
+                "betCount": 0,
+                "betOutcome": "WON",
+                "commission": 0.0,
+                "customerStrategyRef": config.hostname,
+                "eventId": mock_event_id,
+                "eventTypeId": mock_event_type_id,
+                "lastMatchedDate": None,
+                "marketId": "1.234",
+                "placedDate": None,
+                "profit": 0,
+                "settledDate": None,
+            },
         )
 
     def test_info(self):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -296,7 +296,6 @@ class WorkersTest(unittest.TestCase):
             group_by="MARKET",
             customer_strategy_refs=[mock_config.hostname],
         )
-        mock_flumine.log_control.assert_called_with(mock_events.ClearedMarketsEvent())
         mock_flumine.handler_queue.put.assert_called_with(
             mock_events.ClearedMarketsEvent()
         )


### PR DESCRIPTION
minor worker refactor
correctly simulated ClearedMarket call when backtesting/paper trading
process_cleared_markets example added