### PR TITLE
Fix NR Adjustments

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -110,7 +110,7 @@ class SimulatedMiddlewareTest(unittest.TestCase):
         mock_simulated_two = mock.MagicMock(matched=[[123, 8.6, 10]])
         mock_simulated_two.__bool__.return_value = False
         mock_order_two = mock.Mock(simulated=mock_simulated_two, info={})
-        mock_market = mock.Mock(blotter=[mock_order, mock_order_two])
+        mock_market = mock.Mock(blotter=[mock_order, mock_order_two], market_type="WIN")
         self.middleware._process_runner_removal(mock_market, 12345, 0, 16.2)
         self.assertEqual(mock_order.simulated.matched, [[123, 7.21, 10]])
         self.assertEqual(mock_order.simulated.average_price_matched, 7.21)


### PR DESCRIPTION
This is just a preliminary PR for the time being.

 1 Implementing the alternative way of adjusting place markets.
 2 If LAY limit orders have persistence type MARKET_ON_CLOSE, the remaining portion are convert to MARKET_ON_CLOSE orders.

Will the simulated profit on bets from (2) be calculated correctly if there is both a partial fill before the NR adjustment, a remaining portion converted to MARKET_ON_CLOSE?