### PR TITLE
Include min_unit price in make_line_prices

### DIFF
--- a/flumine/utils.py
+++ b/flumine/utils.py
@@ -107,15 +107,13 @@ def make_prices(min_price, cutoffs):
 
 
 def make_line_prices(min_unit: float, max_unit: float, interval: float) -> list:
-    prices = []
+    prices = [min_unit]
     price = min_unit
     while True:
         price += interval
         if price > max_unit:
-            break
-        else:
-            prices.append(price)
-    return prices
+            return prices
+        prices.append(price)
 
 
 PRICES = make_prices(MIN_PRICE, CUTOFFS)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,7 +58,7 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(len(prices), 350)
 
     def test_make_line_prices(self):
-        prices = utils.make_line_prices(-0.5, 9.5, 1.0)
+        prices = utils.make_line_prices(0.5, 9.5, 1.0)
         self.assertEqual(prices, [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5])
 
     def test_get_nearest_price(self):


### PR DESCRIPTION
[Betfair docs](https://docs.developer.betfair.com/display/1smk3cen4v3lu3yomq5qye0ni/Betting+Type+Definitions#BettingTypeDefinitions-MarketLineRangeInfo) make it look like this should be inlcuded
> interval - The odds ladder on this market will be between the range of minUnitValue and maxUnitValue, in increments of the inverval value.e.g. If minUnitValue=10 runs, maxUnitValue=20 runs, interval=0.5 runs, then valid odds include 10, 10.5, 11, 11.5 up to 20 runs.
