### PR TITLE
Lazily evaluate log message parameters

### DIFF
--- a/examples/middleware/orders.py
+++ b/examples/middleware/orders.py
@@ -26,9 +26,8 @@ class OrdersMiddleware(Middleware):
             )
             for current_order in resp.orders:
                 logger.info(
-                    "OrdersMiddleware: Processing order {0}".format(
-                        current_order.bet_id
-                    ),
+                    "OrdersMiddleware: Processing order %s",
+                    current_order.bet_id,
                     extra={
                         "bet_id": current_order.bet_id,
                         "market_id": current_order.market_id,
@@ -51,9 +50,8 @@ class OrdersMiddleware(Middleware):
         strategy = self.flumine.strategies.hashes.get(strategy_name_hash)
         if strategy is None:
             logger.warning(
-                "OrdersMiddleware: Strategy not available to create order {0}".format(
-                    order_id
-                ),
+                "OrdersMiddleware: Strategy not available to create order %s",
+                order_id,
                 extra={
                     "bet_id": current_order.bet_id,
                     "market_id": current_order.market_id,

--- a/examples/strategies/marketrecorder.py
+++ b/examples/strategies/marketrecorder.py
@@ -44,7 +44,7 @@ class MarketRecorder(BaseStrategy):
         self._queue = queue.Queue()
 
     def add(self) -> None:
-        logger.info("Adding strategy %s with id %s" % (self.name, self.recorder_id))
+        logger.info("Adding strategy %s with id %s", self.name, self.recorder_id)
         # check local dir
         if not os.path.isdir(self.local_dir):
             raise OSError("File dir %s does not exist" % self.local_dir)
@@ -94,8 +94,10 @@ class MarketRecorder(BaseStrategy):
         # check that file actually exists
         if not os.path.isfile(file_dir):
             logger.error(
-                "File: %s does not exist in /%s/%s/"
-                % (self.local_dir, market_id, self.recorder_id)
+                "File: %s does not exist in /%s/%s/",
+                self.local_dir,
+                market_id,
+                self.recorder_id,
             )
             return
 
@@ -117,7 +119,7 @@ class MarketRecorder(BaseStrategy):
             # check file still exists (potential race condition)
             if not os.path.isfile(file_dir):
                 logger.warning(
-                    "File: %s does not exist in %s" % (market.market_id, file_dir)
+                    "File: %s does not exist in %s", market.market_id, file_dir
                 )
                 continue
             # compress file
@@ -173,8 +175,7 @@ class MarketRecorder(BaseStrategy):
                 if seconds_since > self._market_expiration:
                     if self._remove_gz_file:
                         logger.info(
-                            "Removing: %s, age: %ss"
-                            % (gz_path, round(seconds_since, 2))
+                            "Removing: %s, age: %ss", gz_path, round(seconds_since, 2)
                         )
                         os.remove(gz_path)
                     txt_path = os.path.join(directory, file.split(".gz")[0])
@@ -183,8 +184,9 @@ class MarketRecorder(BaseStrategy):
                         seconds_since = time.time() - file_stats.st_mtime
                         if seconds_since > self._market_expiration:
                             logger.info(
-                                "Removing: %s, age: %ss"
-                                % (txt_path, round(seconds_since, 2))
+                                "Removing: %s, age: %ss",
+                                txt_path,
+                                round(seconds_since, 2),
                             )
                             os.remove(txt_path)
 

--- a/examples/workers/inplayservice.py
+++ b/examples/workers/inplayservice.py
@@ -34,8 +34,8 @@ def callback(flumine, event):
     for market in flumine.markets:
         if market.event_id == str(score.event_id):
             logger.debug(
-                "Updated market {0} with event {1} scores data".format(
-                    market.market_id, market.event_id
-                )
+                "Updated market %s with event %s scores data",
+                market.market_id,
+                market.event_id,
             )
             market.context["score"] = score

--- a/flumine/baseflumine.py
+++ b/flumine/baseflumine.py
@@ -94,31 +94,31 @@ class BaseFlumine:
         self.add_client_control(client, MaxTransactionCount)
 
     def add_strategy(self, strategy: BaseStrategy) -> None:
-        logger.info("Adding strategy {0}".format(strategy))
+        logger.info("Adding strategy %s", strategy)
         self.streams(strategy)  # create required streams
         self.strategies(strategy, self.clients)  # store in strategies
         self.log_control(events.StrategyEvent(strategy))
 
     def add_worker(self, worker: BackgroundWorker) -> None:
-        logger.info("Adding worker {0}".format(worker.name))
+        logger.info("Adding worker %s", worker.name)
         self._workers.append(worker)
 
     def add_client_control(
         self, client: BaseClient, client_control: Type[BaseControl], **kwargs
     ) -> None:
-        logger.info("Adding client control {0}".format(client_control.NAME))
+        logger.info("Adding client control %s", client_control.NAME)
         client.trading_controls.append(client_control(self, client, **kwargs))
 
     def add_trading_control(self, trading_control: Type[BaseControl], **kwargs) -> None:
-        logger.info("Adding trading control {0}".format(trading_control.NAME))
+        logger.info("Adding trading control %s", trading_control.NAME)
         self.trading_controls.append(trading_control(self, **kwargs))
 
     def add_market_middleware(self, middleware: Middleware) -> None:
-        logger.info("Adding market middleware {0}".format(middleware))
+        logger.info("Adding market middleware %s", middleware)
         self._market_middleware.append(middleware)
 
     def add_logging_control(self, logging_control: LoggingControl) -> None:
-        logger.info("Adding logging control {0}".format(logging_control.NAME))
+        logger.info("Adding logging control %s", logging_control.NAME)
         self._logging_controls.append(logging_control)
 
     def log_control(self, event: events.BaseEvent) -> None:
@@ -199,7 +199,7 @@ class BaseFlumine:
         order_package.client.execution.handler(order_package)
 
     def _add_market(self, market_id: str, market_book: resources.MarketBook) -> Market:
-        logger.info("Adding: {0} to markets".format(market_id))
+        logger.info("Adding: %s to markets", market_id)
         market = Market(self, market_id, market_book)
         self.markets.add_market(market_id, market)
         for middleware in self._market_middleware:
@@ -207,7 +207,7 @@ class BaseFlumine:
         return market
 
     def _remove_market(self, market: Market, clear: bool = True) -> None:
-        logger.info("Removing market {0}".format(market.market_id), extra=self.info)
+        logger.info("Removing market %s", market.market_id, extra=self.info)
         for middleware in self._market_middleware:
             middleware.remove_market(market)
         for strategy in self.strategies:
@@ -244,13 +244,15 @@ class BaseFlumine:
                     market.market_catalogue = market_catalogue
                     self.log_control(events.MarketEvent(market))
                     logger.info(
-                        "Created marketCatalogue for {0}".format(market.market_id),
+                        "Created marketCatalogue for %s",
+                        market.market_id,
                         extra=market.info,
                     )
                 else:
                     market.market_catalogue = market_catalogue
                     logger.info(
-                        "Updated marketCatalogue for {0}".format(market.market_id),
+                        "Updated marketCatalogue for %s",
+                        market.market_id,
                         extra=market.info,
                     )
                 market.update_market_catalogue = False
@@ -275,16 +277,16 @@ class BaseFlumine:
             event.callback(self, event)
         except FlumineException as e:
             logger.error(
-                "FlumineException error {0} in _process_custom_event {1}".format(
-                    e, event.callback
-                ),
+                "FlumineException error %s in _process_custom_event %s",
+                e,
+                event.callback,
                 exc_info=True,
             )
         except Exception as e:
             logger.exception(
-                "Unknown error {0} in _process_custom_event {1}".format(
-                    e, event.callback
-                ),
+                "Unknown error %s in _process_custom_event %s",
+                e,
+                event.callback,
                 exc_info=True,
             )
             if config.raise_errors:
@@ -303,7 +305,8 @@ class BaseFlumine:
         market = self.markets.markets.get(market_id)
         if market is None:
             logger.warning(
-                "Market %s not present when closing" % market_id,
+                "Market %s not present when closing",
+                market_id,
                 extra={"market_id": market_id, **self.info},
             )
             return

--- a/flumine/clients/betfairclient.py
+++ b/flumine/clients/betfairclient.py
@@ -116,11 +116,11 @@ class BetfairClient(BaseClient):
                 ]
             except KeyError:
                 logger.warning(
-                    "min_bet_size KeyError: %s" % self.account_details.currency_code
+                    "min_bet_size KeyError: %s", self.account_details.currency_code
                 )
                 return MIN_BET_SIZE
             except Exception as e:
-                logger.error("min_bet_size error: {0}".format(e), exc_info=True)
+                logger.error("min_bet_size error: %s", e, exc_info=True)
                 return MIN_BET_SIZE
         else:
             return MIN_BET_SIZE
@@ -138,7 +138,7 @@ class BetfairClient(BaseClient):
                 )
                 return MIN_BET_PAYOUT
             except Exception as e:
-                logger.error("min_bet_payout error: {0}".format(e), exc_info=True)
+                logger.error("min_bet_payout error: %s", e, exc_info=True)
                 return MIN_BET_PAYOUT
         else:
             return MIN_BET_PAYOUT
@@ -152,12 +152,11 @@ class BetfairClient(BaseClient):
                 ]
             except KeyError:
                 logger.warning(
-                    "min_bsp_liability KeyError: %s"
-                    % self.account_details.currency_code
+                    "min_bsp_liability KeyError: %s", self.account_details.currency_code
                 )
                 return MIN_BSP_LIABILITY
             except Exception as e:
-                logger.error("min_bsp_liability error: {0}".format(e), exc_info=True)
+                logger.error("min_bsp_liability error: %s", e, exc_info=True)
                 return MIN_BSP_LIABILITY
         else:
             return MIN_BSP_LIABILITY

--- a/flumine/controls/loggingcontrols.py
+++ b/flumine/controls/loggingcontrols.py
@@ -34,7 +34,9 @@ class LoggingControl(Thread):
                     self.process_event(event)
                 except Exception as e:
                     logger.critical(
-                        "{0} exception raised in {1}".format(e, self.NAME),
+                        "%s exception raised in %s",
+                        e,
+                        self.NAME,
                         exc_info=True,
                         extra={"event": event},
                     )
@@ -78,7 +80,7 @@ class LoggingControl(Thread):
             self.logging_queue.put(None)
 
         else:
-            logger.error("Unwanted item in logging control: {0}".format(event))
+            logger.error("Unwanted item in logging control: %s", event)
 
     def _process_config(self, event: events.ConfigEvent) -> None:
         """

--- a/flumine/execution/baseexecution.py
+++ b/flumine/execution/baseexecution.py
@@ -128,7 +128,9 @@ class BaseExecution:
         self, order: BaseOrder, instruction_report, package_type: OrderPackageType
     ):
         logger.info(
-            "Order %s: %s" % (package_type.value, instruction_report.status),
+            "Order %s: %s",
+            package_type.value,
+            instruction_report.status,
             extra={
                 "bet_id": order.bet_id,
                 "order_id": order.id,

--- a/flumine/markets/market.py
+++ b/flumine/markets/market.py
@@ -50,7 +50,8 @@ class Market:
         self.orders_cleared = []
         self.market_cleared = []
         logger.info(
-            "Market {0} opened".format(self.market_id),
+            "Market %s opened",
+            self.market_id,
             extra=self.info,
         )
 
@@ -58,7 +59,8 @@ class Market:
         self.closed = True
         self.date_time_closed = datetime.datetime.utcnow()
         logger.info(
-            "Market {0} closed".format(self.market_id),
+            "Market %s closed",
+            self.market_id,
             extra=self.info,
         )
 

--- a/flumine/markets/middleware.py
+++ b/flumine/markets/middleware.py
@@ -61,9 +61,10 @@ class SimulatedMiddleware(Middleware):
                 )
                 if _removal not in self._runner_removals:
                     logger.warning(
-                        "Runner {0} ({2}) removed from market {3}".format(
-                            *_removal, market.market_id
-                        )
+                        "Runner %s (%s) removed from market %s",
+                        runner.selection_id,
+                        runner.adjustment_factor,
+                        market.market_id,
                     )
                     self._runner_removals.append(_removal)
                     runner_removals.append(_removal)
@@ -105,7 +106,8 @@ class SimulatedMiddleware(Middleware):
                     else:
                         order.simulated.size_voided = order.order_type.liability
                     logger.warning(
-                        "Order voided on non runner {0}".format(order.selection_id),
+                        "Order voided on non runner %s",
+                        order.selection_id,
                         extra=order.info,
                     )
                 else:
@@ -135,9 +137,8 @@ class SimulatedMiddleware(Middleware):
                                     2,
                                 )
                             logger.warning(
-                                "WIN MARKET_ON_CLOSE Order adjusted due to non runner {0}".format(
-                                    order.selection_id
-                                ),
+                                "WIN MARKET_ON_CLOSE Order adjusted due to non runner %s",
+                                order.selection_id,
                                 extra=order.info,
                             )
                         elif market.market_type in {"PLACE", "OTHER_PLACE"}:
@@ -151,9 +152,8 @@ class SimulatedMiddleware(Middleware):
                                     2,
                                 )
                             logger.warning(
-                                "PLACE MARKET_ON_CLOSE Order adjusted due to non runner {0}".format(
-                                    order.selection_id
-                                ),
+                                "PLACE MARKET_ON_CLOSE Order adjusted due to non runner %s",
+                                order.selection_id,
                                 extra=order.info,
                             )
                     elif (
@@ -169,9 +169,8 @@ class SimulatedMiddleware(Middleware):
                             order.simulated.matched
                         )
                         logger.warning(
-                            "Order adjusted due to non runner {0}".format(
-                                order.selection_id
-                            ),
+                            "Order adjusted due to non runner %s",
+                            order.selection_id,
                             extra=order.info,
                         )
 

--- a/flumine/order/process.py
+++ b/flumine/order/process.py
@@ -104,7 +104,8 @@ def create_order_from_current(
     strategy = strategies.hashes.get(strategy_name_hash)
     if strategy is None:
         logger.warning(
-            "Strategy not available to create order {0}".format(order_id),
+            "Strategy not available to create order %s",
+            order_id,
             extra={
                 "bet_id": current_order.bet_id,
                 "market_id": current_order.market_id,

--- a/flumine/simulation/simulatedorder.py
+++ b/flumine/simulation/simulatedorder.py
@@ -208,9 +208,7 @@ class SimulatedOrder:
                     self._piq = avail["size"]
                     break
 
-            logger.debug(
-                "Simulated order {0} PIQ: {1}".format(self.order.id, self._piq)
-            )
+            logger.debug("Simulated order %s PIQ: %s", self.order.id, self._piq)
             return self._create_place_response(bet_id)
         else:
             # validate BSP available, not reconciled and market not inplay
@@ -421,9 +419,9 @@ class SimulatedOrder:
             self.order.execution_complete()
         else:
             logger.warning(
-                "SP not available for order {0} on runner {1}".format(
-                    self.order.id, runner.selection_id
-                )
+                "SP not available for order %s on runner %s",
+                self.order.id,
+                runner.selection_id,
             )
 
     def _process_traded(self, publish_time: int, traded: dict) -> None:
@@ -433,9 +431,10 @@ class SimulatedOrder:
         for traded_price, traded_size in traded.items():
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
-                    "Simulated order {0} traded: {1} - {2}".format(
-                        self.order.id, traded_price, traded_size
-                    )
+                    "Simulated order %s traded: %s - %s",
+                    self.order.id,
+                    traded_price,
+                    traded_size,
                 )
             if side == "BACK" and traded_price >= price:
                 matched = self._calculate_process_traded(publish_time, traded_size)
@@ -464,10 +463,7 @@ class SimulatedOrder:
             return _matched
         else:
             self._piq -= _traded_size
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "Simulated order {0} PIQ: {1}".format(self.order.id, self._piq)
-                )
+            logger.debug("Simulated order %s PIQ: %s", self.order.id, self._piq)
             return traded_size
 
     def _process_available(self, publish_time: int, runner: RunnerBook) -> None:
@@ -515,7 +511,7 @@ class SimulatedOrder:
         return self.order.side
 
     def _update_matched(self, data: List) -> None:
-        logger.debug("Simulated order {0} matched: {1}".format(self.order.id, data))
+        logger.debug("Simulated order %s matched: %s", self.order.id, data)
         self.matched.append(data)
         self.size_matched, self.average_price_matched = wap(self.matched)
 

--- a/flumine/simulation/simulation.py
+++ b/flumine/simulation/simulation.py
@@ -49,7 +49,8 @@ class FlumineSimulation(BaseFlumine):
                 for event_id, streams in event_streams.items():
                     if event_id and len(streams) > 1:
                         logger.info(
-                            "Starting historical event '{0}'".format(event_id),
+                            "Starting historical event '%s'",
+                            event_id,
                             extra={
                                 "event_id": event_id,
                                 "markets": [s.market_filter for s in streams],
@@ -82,13 +83,12 @@ class FlumineSimulation(BaseFlumine):
                             # add back
                             cycles.append([publish_time_epoch, market_book, stream_gen])
                         self.handler_queue.clear()
-                        logger.info("Completed historical event '{0}'".format(event_id))
+                        logger.info("Completed historical event '%s'", event_id)
                     else:
                         for stream in streams:
                             logger.info(
-                                "Starting historical market '{0}'".format(
-                                    stream.market_filter
-                                ),
+                                "Starting historical market '%s'",
+                                stream.market_filter,
                                 extra={"market": stream.market_filter},
                             )
                             self.simulated_datetime.reset_real_datetime()
@@ -99,9 +99,7 @@ class FlumineSimulation(BaseFlumine):
                                 )
                             self.handler_queue.clear()
                             logger.info(
-                                "Completed historical market '{0}'".format(
-                                    stream.market_filter
-                                )
+                                "Completed historical market '%s'", stream.market_filter
                             )
                 self._process_end_flumine()
                 logger.info("Simulation complete")

--- a/flumine/strategy/strategy.py
+++ b/flumine/strategy/strategy.py
@@ -264,7 +264,7 @@ class Strategies:
 
     def __call__(self, strategy: BaseStrategy, clients) -> None:
         if strategy.name in [s.name for s in self]:
-            logger.warning("Strategy of same name '{0}' already added".format(strategy))
+            logger.warning("Strategy of same name '%s' already added", strategy)
         strategy.clients = clients
         self._strategies.append(strategy)
         strategy.add()

--- a/flumine/streams/datastream.py
+++ b/flumine/streams/datastream.py
@@ -56,15 +56,19 @@ class FlumineMarketStream(FlumineStream):
                     # removes closed market from cache
                     del self._caches[market_id]
                     logger.info(
-                        "[MarketStream: %s] %s removed, %s markets in cache"
-                        % (self.unique_id, market_id, len(self._caches))
+                        "[MarketStream: %s] %s removed, %s markets in cache",
+                        self.unique_id,
+                        market_id,
+                        len(self._caches),
                     )
             elif market_id not in self._caches:
                 # adds empty object to cache to track live market count
                 self._caches[market_id] = object()
                 logger.info(
-                    "[MarketStream: %s] %s added, %s markets in cache"
-                    % (self.unique_id, market_id, len(self._caches))
+                    "[MarketStream: %s] %s added, %s markets in cache",
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
             self._updates_processed += 1
 
@@ -82,8 +86,10 @@ class FlumineOrderStream(FlumineStream):
                 # adds empty object to cache to track live market count
                 self._caches[market_id] = object()
                 logger.info(
-                    "[OrderStream: %s] %s added, %s markets in cache"
-                    % (self.unique_id, market_id, len(self._caches))
+                    "[OrderStream: %s] %s added, %s markets in cache",
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
             self._updates_processed += 1
 
@@ -101,8 +107,10 @@ class FlumineRaceStream(FlumineStream):
                 # adds empty object to cache to track live market count
                 self._caches[market_id] = object()
                 logger.info(
-                    "[RaceStream: %s] %s added, %s markets in cache"
-                    % (self.unique_id, market_id, len(self._caches))
+                    "[RaceStream: %s] %s added, %s markets in cache",
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
             self._updates_processed += 1
 
@@ -120,8 +128,10 @@ class FlumineCricketStream(FlumineStream):
                 # adds empty object to cache to track live market count
                 self._caches[market_id] = object()
                 logger.info(
-                    "[CricketStream: %s] %s added, %s markets in cache"
-                    % (self.unique_id, market_id, len(self._caches))
+                    "[CricketStream: %s] %s added, %s markets in cache",
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
             self._updates_processed += 1
 
@@ -139,7 +149,8 @@ class DataStream(BaseStream):
     @retry(wait=RETRY_WAIT)
     def run(self) -> None:
         logger.info(
-            "Starting DataStream {0}".format(self.stream_id),
+            "Starting DataStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
                 "market_filter": self.market_filter,
@@ -160,23 +171,20 @@ class DataStream(BaseStream):
             )
             self._stream.start()
         except BetfairError:
-            logger.error(
-                "DataStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.error("DataStream %s run error", self.stream_id, exc_info=True)
             raise
         except Exception:
-            logger.critical(
-                "DataStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.critical("DataStream %s run error", self.stream_id, exc_info=True)
             raise
-        logger.info("Stopped DataStream {0}".format(self.stream_id))
+        logger.info("Stopped DataStream %s", self.stream_id)
 
 
 class OrderDataStream(DataStream):
     @retry(wait=RETRY_WAIT)
     def run(self) -> None:
         logger.info(
-            "Starting OrderDataStream {0}".format(self.stream_id),
+            "Starting OrderDataStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
                 "customer_strategy_refs": config.customer_strategy_ref,
@@ -200,23 +208,22 @@ class OrderDataStream(DataStream):
             )
             self._stream.start()
         except BetfairError:
-            logger.error(
-                "OrderDataStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.error("OrderDataStream %s run error", self.stream_id, exc_info=True)
             raise
         except Exception:
             logger.critical(
-                "OrderDataStream {0} run error".format(self.stream_id), exc_info=True
+                "OrderDataStream %s run error", self.stream_id, exc_info=True
             )
             raise
-        logger.info("Stopped OrderDataStream {0}".format(self.stream_id))
+        logger.info("Stopped OrderDataStream %s", self.stream_id)
 
 
 class RaceDataStream(DataStream):
     @retry(wait=RETRY_WAIT)
     def run(self) -> None:
         logger.info(
-            "Starting RaceDataStream {0}".format(self.stream_id),
+            "Starting RaceDataStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
             },
@@ -228,23 +235,22 @@ class RaceDataStream(DataStream):
             self.stream_id = self._stream.subscribe_to_races()
             self._stream.start()
         except BetfairError:
-            logger.error(
-                "RaceDataStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.error("RaceDataStream %s run error", self.stream_id, exc_info=True)
             raise
         except Exception:
             logger.critical(
-                "RaceDataStream {0} run error".format(self.stream_id), exc_info=True
+                "RaceDataStream %s run error", self.stream_id, exc_info=True
             )
             raise
-        logger.info("Stopped RaceDataStream {0}".format(self.stream_id))
+        logger.info("Stopped RaceDataStream %s", self.stream_id)
 
 
 class CricketDataStream(DataStream):
     @retry(wait=RETRY_WAIT)
     def run(self) -> None:
         logger.info(
-            "Starting CricketDataStream {0}".format(self.stream_id),
+            "Starting CricketDataStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
             },
@@ -257,12 +263,12 @@ class CricketDataStream(DataStream):
             self._stream.start()
         except BetfairError:
             logger.error(
-                "CricketDataStream {0} run error".format(self.stream_id), exc_info=True
+                "CricketDataStream %s run error", self.stream_id, exc_info=True
             )
             raise
         except Exception:
             logger.critical(
-                "CricketDataStream {0} run error".format(self.stream_id), exc_info=True
+                "CricketDataStream %s run error", self.stream_id, exc_info=True
             )
             raise
-        logger.info("Stopped CricketDataStream {0}".format(self.stream_id))
+        logger.info("Stopped CricketDataStream %s", self.stream_id)

--- a/flumine/streams/historicalstream.py
+++ b/flumine/streams/historicalstream.py
@@ -43,8 +43,10 @@ class FlumineMarketStream(MarketStream):
                     logger.warning(
                         "[%s: %s]: Missing marketDefinition on market %s resulting "
                         "in potential missing data in the MarketBook (make sure "
-                        "EX_MARKET_DEF is requested)"
-                        % (self, self.unique_id, market_id)
+                        "EX_MARKET_DEF is requested)",
+                        self,
+                        self.unique_id,
+                        market_id,
                     )
                 market_book_cache = MarketBookCache(
                     market_id,
@@ -55,8 +57,11 @@ class FlumineMarketStream(MarketStream):
                 )
                 self._caches[market_id] = market_book_cache
                 logger.info(
-                    "[%s: %s]: %s added, %s markets in cache"
-                    % (self, self.unique_id, market_id, len(self._caches))
+                    "[%s: %s]: %s added, %s markets in cache",
+                    self,
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
 
             # listener_kwargs filtering
@@ -116,8 +121,11 @@ class FlumineRaceStream(RaceStream):
                 race_cache.start_time = create_time(publish_time, race_id)
                 self._caches[market_id] = race_cache
                 logger.info(
-                    "[%s: %s]: %s added, %s markets in cache"
-                    % (self, self.unique_id, market_id, len(self._caches))
+                    "[%s: %s]: %s added, %s markets in cache",
+                    self,
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
 
             # filter after start time
@@ -151,8 +159,11 @@ class FlumineCricketStream(CricketStream):
                 )
                 self._caches[market_id] = cricket_match_cache
                 logger.info(
-                    "[%s: %s]: %s added, %s markets in cache"
-                    % (self, self.unique_id, market_id, len(self._caches))
+                    "[%s: %s]: %s added, %s markets in cache",
+                    self,
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
 
             cricket_match_cache.update_cache(cricket_change, publish_time)

--- a/flumine/streams/marketstream.py
+++ b/flumine/streams/marketstream.py
@@ -15,7 +15,8 @@ class MarketStream(BaseStream):
     @retry(wait=RETRY_WAIT)
     def run(self) -> None:
         logger.info(
-            "Starting MarketStream {0}".format(self.stream_id),
+            "Starting MarketStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
                 "market_filter": self.market_filter,
@@ -25,9 +26,7 @@ class MarketStream(BaseStream):
             },
         )
         if not self._output_thread.is_alive():
-            logger.info(
-                "Starting output_thread (MarketStream {0})".format(self.stream_id)
-            )
+            logger.info("Starting output_thread (MarketStream %s)", self.stream_id)
             self._output_thread.start()
 
         self._stream = self.betting_client.streaming.create_stream(
@@ -43,16 +42,12 @@ class MarketStream(BaseStream):
             )
             self._stream.start()
         except BetfairError:
-            logger.error(
-                "MarketStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.error("MarketStream %s run error", self.stream_id, exc_info=True)
             raise
         except Exception:
-            logger.critical(
-                "MarketStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.critical("MarketStream %s run error", self.stream_id, exc_info=True)
             raise
-        logger.info("Stopped MarketStream {0}".format(self.stream_id))
+        logger.info("Stopped MarketStream %s", self.stream_id)
 
     def handle_output(self) -> None:
         """Handles output from stream."""
@@ -68,4 +63,4 @@ class MarketStream(BaseStream):
             if market_books:
                 self.flumine.handler_queue.put(MarketBookEvent(market_books))
 
-        logger.info("Stopped output_thread (MarketStream {0})".format(self.stream_id))
+        logger.info("Stopped output_thread (MarketStream %s)", self.stream_id)

--- a/flumine/streams/orderstream.py
+++ b/flumine/streams/orderstream.py
@@ -19,7 +19,8 @@ class OrderStream(BaseStream):
     @retry(wait=RETRY_WAIT)
     def run(self) -> None:
         logger.info(
-            "Starting OrderStream {0}".format(self.stream_id),
+            "Starting OrderStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
                 "customer_strategy_refs": config.customer_strategy_ref,
@@ -29,9 +30,7 @@ class OrderStream(BaseStream):
             },
         )
         if not self._output_thread.is_alive():
-            logger.info(
-                "Starting output_thread (OrderStream {0})".format(self.stream_id)
-            )
+            logger.info("Starting output_thread (OrderStream %s)", self.stream_id)
             self._output_thread.start()
 
         self._stream = self.betting_client.streaming.create_stream(
@@ -50,16 +49,12 @@ class OrderStream(BaseStream):
             )
             self._stream.start()
         except BetfairError:
-            logger.error(
-                "OrderStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.error("OrderStream %s run error", self.stream_id, exc_info=True)
             raise
         except Exception:
-            logger.critical(
-                "OrderStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.critical("OrderStream %s run error", self.stream_id, exc_info=True)
             raise
-        logger.info("Stopped OrderStream {0}".format(self.stream_id))
+        logger.info("Stopped OrderStream %s", self.stream_id)
 
     def handle_output(self) -> None:
         """Handles output from stream, snaps
@@ -88,4 +83,4 @@ class OrderStream(BaseStream):
                     order_book.client = self.client
                 self.flumine.handler_queue.put(CurrentOrdersEvent(order_books))
 
-        logger.info("Stopped output_thread (OrderStream {0})".format(self.stream_id))
+        logger.info("Stopped output_thread (OrderStream %s)", self.stream_id)

--- a/flumine/streams/simulatedorderstream.py
+++ b/flumine/streams/simulatedorderstream.py
@@ -17,7 +17,8 @@ class CurrentOrders:
 class SimulatedOrderStream(BaseStream):
     def run(self) -> None:
         logger.info(
-            "Starting SimulatedOrderStream {0}".format(self.stream_id),
+            "Starting SimulatedOrderStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
                 "streaming_timeout": self.streaming_timeout,
@@ -32,7 +33,7 @@ class SimulatedOrderStream(BaseStream):
                         CurrentOrdersEvent([CurrentOrders(current_orders, self.client)])
                     )
             time.sleep(self.streaming_timeout)
-        logger.info("Stopped SimulatedOrderStream {0}".format(self.stream_id))
+        logger.info("Stopped SimulatedOrderStream %s", self.stream_id)
 
     def _get_current_orders(self) -> list:
         current_orders = []

--- a/flumine/streams/sportsdatastream.py
+++ b/flumine/streams/sportsdatastream.py
@@ -17,7 +17,8 @@ class SportsDataStream(BaseStream):
     def run(self) -> None:
         time.sleep(2)  # 2s delay to wait for market streams to start
         logger.info(
-            "Starting SportsDataStream {0}".format(self.stream_id),
+            "Starting SportsDataStream %s",
+            self.stream_id,
             extra={
                 "stream_id": self.stream_id,
                 "sports_data_filter": self.sports_data_filter,
@@ -25,9 +26,7 @@ class SportsDataStream(BaseStream):
             },
         )
         if not self._output_thread.is_alive():
-            logger.info(
-                "Starting output_thread (SportsDataStream {0})".format(self.stream_id)
-            )
+            logger.info("Starting output_thread (SportsDataStream %s)", self.stream_id)
             self._output_thread.start()
 
         self._stream = self.betting_client.streaming.create_stream(
@@ -42,16 +41,14 @@ class SportsDataStream(BaseStream):
                 raise ValueError("Unknown sports data filter")
             self._stream.start()
         except BetfairError:
-            logger.error(
-                "SportsDataStream {0} run error".format(self.stream_id), exc_info=True
-            )
+            logger.error("SportsDataStream %s run error", self.stream_id, exc_info=True)
             raise
         except Exception:
             logger.critical(
-                "SportsDataStream {0} run error".format(self.stream_id), exc_info=True
+                "SportsDataStream %s run error", self.stream_id, exc_info=True
             )
             raise
-        logger.info("Stopped SportsDataStream {0}".format(self.stream_id))
+        logger.info("Stopped SportsDataStream %s", self.stream_id)
 
     def handle_output(self) -> None:
         """Handles output from stream."""
@@ -67,6 +64,4 @@ class SportsDataStream(BaseStream):
             if sports_data:
                 self.flumine.handler_queue.put(SportsDataEvent(sports_data))
 
-        logger.info(
-            "Stopped output_thread (SportsDataStream {0})".format(self.stream_id)
-        )
+        logger.info("Stopped output_thread (SportsDataStream %s)", self.stream_id)

--- a/flumine/streams/streams.py
+++ b/flumine/streams/streams.py
@@ -31,14 +31,11 @@ class Streams:
             listener_kwargs = strategy.market_filter.get("listener_kwargs", {})
             if markets and events:
                 logger.warning(
-                    "Markets and events found for strategy {0} skipping as flumine can only handle one type".format(
-                        strategy
-                    )
+                    "Markets and events found for strategy %s skipping as flumine can only handle one type",
+                    strategy,
                 )
             elif markets is None and events is None:
-                logger.warning(
-                    "No markets or events found for strategy {0}".format(strategy)
-                )
+                logger.warning("No markets or events found for strategy %s", strategy)
             elif markets:
                 # order markets by name as an attempt to process in chronological order
                 markets.sort()
@@ -47,8 +44,10 @@ class Streams:
                     country_code = get_file_md(market, "countryCode")
                     if market_types and market_type and market_type not in market_types:
                         logger.warning(
-                            "Skipping market %s (%s) for strategy %s due to marketType filter"
-                            % (market, market_type, strategy)
+                            "Skipping market %s (%s) for strategy %s due to marketType filter",
+                            market,
+                            market_type,
+                            strategy,
                         )
                     elif (
                         country_codes
@@ -95,18 +94,20 @@ class Streams:
                     and stream.conflate_ms == strategy.conflate_ms
                 ):
                     logger.info(
-                        "Using {0} ({1}) for strategy {2}".format(
-                            strategy.stream_class, stream.stream_id, strategy
-                        )
+                        "Using %s (%s) for strategy %s",
+                        strategy.stream_class,
+                        stream.stream_id,
+                        strategy,
                     )
                     strategy.streams.append(stream)
                     break
             else:  # nope? lets create a new one
                 stream_id = self._increment_stream_id()
                 logger.info(
-                    "Creating new {0} ({1}) for strategy {2}".format(
-                        strategy.stream_class, stream_id, strategy
-                    )
+                    "Creating new %s (%s) for strategy %s",
+                    strategy.stream_class,
+                    stream_id,
+                    strategy,
                 )
                 stream = strategy.stream_class(
                     flumine=self.flumine,
@@ -127,18 +128,20 @@ class Streams:
                     and stream.streaming_timeout == strategy.streaming_timeout
                 ):
                     logger.info(
-                        "Using {0} ({1}) for strategy {2}".format(
-                            strategy.stream_class, stream.stream_id, strategy
-                        )
+                        "Using %s (%s) for strategy %s",
+                        strategy.stream_class,
+                        stream.stream_id,
+                        strategy,
                     )
                     strategy.streams.append(stream)
                     break
             else:  # nope? lets create a new one
                 stream_id = self._increment_stream_id()
                 logger.info(
-                    "Creating new {0} ({1}) for strategy {2}".format(
-                        strategy.stream_class, stream_id, strategy
-                    )
+                    "Creating new %s (%s) for strategy %s",
+                    strategy.stream_class,
+                    stream_id,
+                    strategy,
                 )
                 stream = SportsDataStream(
                     flumine=self.flumine,
@@ -169,9 +172,10 @@ class Streams:
             if event_processing and event_id is None:
                 logger.warning("EventId not found for market %s" % market)
             logger.info(
-                "Creating new {0} ({1}) for strategy {2}".format(
-                    HistoricalStream.__name__, stream_id, strategy
-                ),
+                "Creating new %s (%s) for strategy %s",
+                HistoricalStream.__name__,
+                stream_id,
+                strategy,
                 extra={
                     "strategy": strategy,
                     "stream_id": stream_id,
@@ -220,9 +224,7 @@ class Streams:
         conflate_ms: int = None,
         streaming_timeout: float = 0.25,
     ) -> SimulatedOrderStream:
-        logger.warning(
-            "Client {0} now paper trading".format(client.betting_client.username)
-        )
+        logger.warning("Client %s now paper trading", client.betting_client.username)
         stream_id = self._increment_stream_id()
         stream = SimulatedOrderStream(
             flumine=self.flumine,

--- a/flumine/utils.py
+++ b/flumine/utils.py
@@ -237,12 +237,18 @@ def call_strategy_error_handling(
         return func(market, market_book)
     except FlumineException as e:
         logger.error(
-            "FlumineException %s in %s (%s)" % (e, func.__name__, market.market_id),
+            "FlumineException %s in %s (%s)",
+            e,
+            func.__name__,
+            market.market_id,
             exc_info=True,
         )
     except Exception as e:
         logger.critical(
-            "Unknown error %s in %s (%s)" % (e, func.__name__, market.market_id),
+            "Unknown error %s in %s (%s)",
+            e,
+            func.__name__,
+            market.market_id,
             exc_info=True,
         )
         if config.raise_errors:
@@ -255,12 +261,18 @@ def call_middleware_error_handling(middleware, market) -> None:
         middleware(market)
     except FlumineException as e:
         logger.error(
-            "FlumineException %s in %s (%s)" % (e, middleware, market.market_id),
+            "FlumineException %s in %s (%s)",
+            e,
+            middleware,
+            market.market_id,
             exc_info=True,
         )
     except Exception as e:
         logger.critical(
-            "Unknown error %s in %s (%s)" % (e, middleware, market.market_id),
+            "Unknown error %s in %s (%s)",
+            e,
+            middleware,
+            market.market_id,
             exc_info=True,
         )
         if config.raise_errors:
@@ -272,12 +284,18 @@ def call_process_orders_error_handling(strategy, market, strategy_orders: list) 
         strategy.process_orders(market, strategy_orders)
     except FlumineException as e:
         logger.error(
-            "FlumineException %s in %s (%s)" % (e, strategy, market.market_id),
+            "FlumineException %s in %s (%s)",
+            e,
+            strategy,
+            market.market_id,
             exc_info=True,
         )
     except Exception as e:
         logger.critical(
-            "Unknown error %s in %s (%s)" % (e, strategy, market.market_id),
+            "Unknown error %s in %s (%s)",
+            e,
+            strategy,
+            market.market_id,
             exc_info=True,
         )
         if config.raise_errors:
@@ -289,12 +307,16 @@ def call_process_raw_data(strategy, clk: str, publish_time: int, datum: dict) ->
         strategy.process_raw_data(clk, publish_time, datum)
     except FlumineException as e:
         logger.error(
-            "FlumineException %s in %s" % (e, strategy),
+            "FlumineException %s in %s",
+            e,
+            strategy,
             exc_info=True,
         )
     except Exception as e:
         logger.critical(
-            "Unknown error %s in %s" % (e, strategy),
+            "Unknown error %s in %s",
+            e,
+            strategy,
             exc_info=True,
         )
         if config.raise_errors:

--- a/flumine/worker.py
+++ b/flumine/worker.py
@@ -38,7 +38,8 @@ class BackgroundWorker(threading.Thread):
 
     def run(self) -> None:
         logger.info(
-            "BackgroundWorker {0} starting".format(self.name),
+            "BackgroundWorker %s starting",
+            self.name,
             extra={
                 "worker_name": self.name,
                 "function": self.function,
@@ -53,7 +54,8 @@ class BackgroundWorker(threading.Thread):
         self._running = True
         while self._running:
             logger.debug(
-                "BackgroundWorker {0} executing".format(self.name),
+                "BackgroundWorker %s executing",
+                self.name,
                 extra={
                     "worker_name": self.name,
                     "function": self.function,
@@ -66,7 +68,9 @@ class BackgroundWorker(threading.Thread):
                 )
             except Exception as e:
                 logger.error(
-                    "Error in BackgroundWorker {0}: {1}".format(self.name, e),
+                    "Error in BackgroundWorker %s: %s",
+                    self.name,
+                    e,
                     extra={
                         "worker_name": self.name,
                         "function": self.function,
@@ -80,7 +84,8 @@ class BackgroundWorker(threading.Thread):
 
     def shutdown(self, timeout: int = 4) -> None:
         logger.info(
-            "BackgroundWorker {0} shutting down".format(self.name),
+            "BackgroundWorker %s shutting down",
+            self.name,
             extra={
                 "worker_name": self.name,
                 "function": self.function,
@@ -210,9 +215,10 @@ def _get_cleared_orders(flumine, betting_client, market_id: str) -> bool:
             return False
 
         logger.info(
-            "{0}: {1} cleared orders found, more available: {2}".format(
-                market_id, len(cleared_orders.orders), cleared_orders.more_available
-            )
+            "%s: %s cleared orders found, more available: %s",
+            market_id,
+            len(cleared_orders.orders),
+            cleared_orders.more_available,
         )
         cleared_orders.market_id = market_id
         flumine.handler_queue.put(events.ClearedOrdersEvent(cleared_orders))


### PR DESCRIPTION
Logging like this:

    logger.debug("Hello, %s" % name)

causes the message string to always be interpolated even if the message is not going to be logged.

Logging like this:

    logger.debug("Hello, %s", name)

will mean the string is only ever interpolated if it will be logged.

In practice here this will make little difference if the log level is INFO
or above.

See:

https://docs.python.org/3/howto/logging.html#optimization https://stackoverflow.com/questions/4148790/lazy-logger-message-string-evaluation