### PR TITLE
Add [speed]

### DIFF
--- a/requirements-speed.txt
+++ b/requirements-speed.txt
@@ -1,0 +1,1 @@
+betfairlightweight[speed]==2.17.3

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,12 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, "requirements.txt")) as f:
     INSTALL_REQUIRES = f.read().splitlines()
 
+with open(os.path.join(here, "requirements-speed.txt")) as f:
+    extras_require = f.read().splitlines()
+    EXTRAS_REQUIRE = {
+        "speed": extras_require,
+    }
+
 about = {}
 with open(os.path.join(here, "flumine", "__version__.py"), "r") as f:
     exec(f.read(), about)
@@ -27,6 +33,7 @@ setup(
     ),
     package_dir={"flumine": "flumine"},
     install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
     url=about["__url__"],
     license=about["__license__"],
     author=about["__author__"],


### PR DESCRIPTION
Previously requirements.txt/install_requires only required:

    betfairlightweight==2.17.3

which will not bring in the faster libraries that
betfairlightweight[speed] would bring in.

If you're running a standalone virtual environment for flumine then you can easily miss out on these faster dependencies.

This adds a [speed] mode which simply depends on
betfairlightweight[speed] ensuring that the right versions of the transitive dependencies are pulled in for the given version of bflw.