### PR TITLE
Change utils.get_file_md to return a MarketDefinition

### DIFF
--- a/flumine/streams/streams.py
+++ b/flumine/streams/streams.py
@@ -1,6 +1,6 @@
 import time
 import logging
-from typing import Union, Iterator
+from typing import Optional, Union, Iterator
 
 from ..strategy.strategy import BaseStrategy
 from .marketstream import MarketStream
@@ -11,6 +11,7 @@ from .orderstream import OrderStream
 from .simulatedorderstream import SimulatedOrderStream
 from ..clients import ExchangeType, BaseClient
 from ..utils import get_file_md
+from betfairlightweight.resources.streamingresources import MarketDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +44,9 @@ class Streams:
                 # order markets by name as an attempt to process in chronological order
                 markets.sort()
                 for market in markets:
-                    market_type = get_file_md(market, "marketType")
-                    country_code = get_file_md(market, "countryCode")
+                    market_definition = get_file_md(market)
+                    market_type = getattr(market_definition, "market_type", None)
+                    country_code = getattr(market_definition, "country_code", None)
                     if market_types and market_type and market_type not in market_types:
                         logger.warning(
                             "Skipping market %s (%s) for strategy %s due to marketType filter"
@@ -61,7 +63,11 @@ class Streams:
                         )
                     else:
                         stream = self.add_historical_stream(
-                            strategy, market, event_processing, **listener_kwargs
+                            strategy,
+                            market,
+                            market_definition,
+                            event_processing,
+                            **listener_kwargs,
                         )
                         strategy.streams.append(stream)
                         strategy.historic_stream_ids.append(stream.stream_id)
@@ -153,6 +159,7 @@ class Streams:
         self,
         strategy: BaseStrategy,
         market: str,
+        market_definition: Optional[MarketDefinition],
         event_processing: bool,
         **listener_kwargs
     ) -> HistoricalStream:
@@ -165,7 +172,7 @@ class Streams:
                 return stream
         else:
             stream_id = self._increment_stream_id()
-            event_id = get_file_md(market, "eventId")
+            event_id = getattr(market_definition, "event_id", None)
             if event_processing and event_id is None:
                 logger.warning("EventId not found for market %s" % market)
             logger.info(

--- a/flumine/utils.py
+++ b/flumine/utils.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Optional, Tuple, Callable, Union
 from decimal import Decimal, ROUND_HALF_UP
 from betfairlightweight.resources.bettingresources import MarketBook, RunnerBook
+from betfairlightweight.resources.streamingresources import MarketDefinition
+
 
 from . import config
 from .exceptions import FlumineException
@@ -59,7 +61,7 @@ def file_line_count(file_path: str) -> int:
     return i + 1
 
 
-def get_file_md(file_dir: Union[str, tuple], value: str) -> Optional[str]:
+def get_file_md(file_dir: Union[str, tuple]) -> Optional[MarketDefinition]:
     # get value from raw streaming file marketDefinition
     if isinstance(file_dir, tuple):
         file_dir = file_dir[0]
@@ -69,7 +71,7 @@ def get_file_md(file_dir: Union[str, tuple], value: str) -> Optional[str]:
     if "mc" not in update or not isinstance(update["mc"], list) or not update["mc"]:
         return None
     md = update["mc"][0].get("marketDefinition", {})
-    return md.get(value)
+    return MarketDefinition(**md)
 
 
 def chunks(l: list, n: int) -> list:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,12 +27,12 @@ class UtilsTest(unittest.TestCase):
 
     def test_get_file_event_id(self):
         self.assertEqual(
-            utils.get_file_md("tests/resources/PRO-1.170258213", "eventId"), "29761984"
+            utils.get_file_md("tests/resources/PRO-1.170258213").event_id, "29761984"
         )
 
     def test_get_file_event_id_tuple(self):
         self.assertEqual(
-            utils.get_file_md(("tests/resources/PRO-1.170258213", "test"), "eventId"),
+            utils.get_file_md(("tests/resources/PRO-1.170258213", "test")).event_id,
             "29761984",
         )
 


### PR DESCRIPTION
Previously get_file_md was called three separate times while setting up a historical stream, meaning three opens/reads/JSON parsings per recorded stream.

This changes get_file_md to return a MarketDefinition object containing all of the available market definition information (previously only one field at a time was fetched). This allows the number of calls to get_file_md to be reduced to one and therefore speed up processing of historical data.