### PR TITLE
Improve performance of SimulatedMiddleware._process_runner

### DIFF
--- a/flumine/markets/middleware.py
+++ b/flumine/markets/middleware.py
@@ -245,12 +245,11 @@ class SimulatedMiddleware(Middleware):
 
     @staticmethod
     def _process_runner(market_analytics: dict, runner: RunnerBook) -> None:
-        try:
-            runner_analytics = market_analytics[(runner.selection_id, runner.handicap)]
-        except KeyError:
-            runner_analytics = market_analytics[
-                (runner.selection_id, runner.handicap)
-            ] = RunnerAnalytics(runner)
+        key = (runner.selection_id, runner.handicap)
+        if key in market_analytics:
+            runner_analytics = market_analytics[key]
+        else:
+            runner_analytics = market_analytics[key] = RunnerAnalytics(runner)
         runner_analytics(runner)
 
 


### PR DESCRIPTION
This method is on the hot path of the simulation so even a small improvement here is quite useful. It's faster to check if the key is in the dictionary usin `in` rather than blindly trying to get it and handling the KeyError.

Benchmark

https://gist.github.com/petedmarsh/0e632aa9aeaf6bfc2acf1dac03319c1a

                                              Benchmarks, repeat=5, number=5
    ┌────────────────────────────┬─────────┬─────────┬─────────┬─────────────────┬─────────────────┬─────────────────┐
    │                  Benchmark │ Min     │ Max     │ Mean    │ Min (+)         │ Max (+)         │ Mean (+)        │
    ├────────────────────────────┼─────────┼─────────┼─────────┼─────────────────┼─────────────────┼─────────────────┤
    │ Using KeyError vs using in │ 3.406   │ 3.419   │ 3.411   │ 2.598 (1.3x)    │ 2.616 (1.3x)    │ 2.605 (1.3x)    │
    │ Using in with a cached key │ 2.600   │ 2.611   │ 2.605   │ 2.481 (1.0x)    │ 2.516 (1.0x)    │ 2.497 (1.0x)    │
    └────────────────────────────┴─────────┴─────────┴─────────┴─────────────────┴─────────────────┴─────────────────┘