### PR TITLE
#706 Fix FOK simulation error, update tests to cover the bug

### DIFF
--- a/flumine/simulation/simulatedorder.py
+++ b/flumine/simulation/simulatedorder.py
@@ -101,7 +101,7 @@ class SimulatedOrder:
             size = self.order.order_type.size
             if "limitOrder" in instruction:
                 time_in_force = instruction["limitOrder"].get("timeInForce")
-                min_fill_size = instruction["limitOrder"].get("minFillSize", 0)
+                min_fill_size = instruction["limitOrder"].get("minFillSize") or 0
             else:
                 time_in_force = None
                 min_fill_size = None


### PR DESCRIPTION
Fixes #706. Tests for simulated order have been updated to pick up this kind of bugs. After the update, 6 tests were failing before the fix was implemented, previously none.