### PR TITLE
Add black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.11

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 # Tests & Linting
 black==23.9.1
 coverage
+pre-commit
 
 # Documentation
 mkdocs


### PR DESCRIPTION
I've lost count the number of times I had CI tests failing because I forgot to run `black .` before pushing. You may want to add `black` pre-commit hook to the repo to have black run automatically on every commit. It is trivial to install and use:
```
pip install pre-commit
pre-commit install
```

FYI, using this hook is not enforced and is entirely optional for those who care to install it.

More info: https://pre-commit.com/