### PR TITLE
Market event filter for golf

### DIFF
--- a/flumine/markets/market.py
+++ b/flumine/markets/market.py
@@ -116,7 +116,7 @@ class Market:
         for market in self.flumine.markets.events[self.event_id]:
             if (
                 market_start_datetime == market.market_start_datetime
-                or event_type_id == "1"
+                or event_type_id in ["1", "3"]  # soccer, golf
             ):
                 event[market.market_type].append(market)
         return event

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -231,7 +231,9 @@ class MarketTest(unittest.TestCase):
         m_three = mock.Mock(market_type=3, event_id=123, market_start_datetime=12)
         m_four = mock.Mock(market_type=1, event_id=12, market_start_datetime=12)
         m_five = mock.Mock(market_type=2, event_id=12, market_start_datetime=13)
-        m_six = mock.Mock(market_type=2, event_id=13, market_start_datetime=13) # different event
+        m_six = mock.Mock(
+            market_type=2, event_id=13, market_start_datetime=13
+        )  # different event
         self.market.flumine.markets.events[m_one.event_id].append(m_one)
         self.market.flumine.markets.events[m_two.event_id].append(m_two)
         self.market.flumine.markets.events[m_three.event_id].append(m_three)
@@ -247,12 +249,24 @@ class MarketTest(unittest.TestCase):
         self.market.flumine.markets.events = defaultdict(list)
         self.assertEqual(self.market.event, {})
 
-        m_one = mock.Mock(market_type=1, event_id=12, event_type_id="1", market_start_datetime=12)
-        m_two = mock.Mock(market_type=2, event_id=12, event_type_id="1", market_start_datetime=12)
-        m_three = mock.Mock(market_type=3, event_id=123, event_type_id="1", market_start_datetime=12)
-        m_four = mock.Mock(market_type=2, event_id=12, event_type_id="1", market_start_datetime=13)
-        m_five = mock.Mock(market_type=1, event_id=13, event_type_id="1", market_start_datetime=13)
-        m_six = mock.Mock(market_type=2, event_id=13, event_type_id="3", market_start_datetime=13)
+        m_one = mock.Mock(
+            market_type=1, event_id=12, event_type_id="1", market_start_datetime=12
+        )
+        m_two = mock.Mock(
+            market_type=2, event_id=12, event_type_id="1", market_start_datetime=12
+        )
+        m_three = mock.Mock(
+            market_type=3, event_id=123, event_type_id="1", market_start_datetime=12
+        )
+        m_four = mock.Mock(
+            market_type=2, event_id=12, event_type_id="1", market_start_datetime=13
+        )
+        m_five = mock.Mock(
+            market_type=1, event_id=13, event_type_id="1", market_start_datetime=13
+        )
+        m_six = mock.Mock(
+            market_type=2, event_id=13, event_type_id="3", market_start_datetime=13
+        )
         self.market.flumine.markets.events[m_one.event_id].append(m_one)
         self.market.flumine.markets.events[m_two.event_id].append(m_two)
         self.market.flumine.markets.events[m_three.event_id].append(m_three)
@@ -265,7 +279,9 @@ class MarketTest(unittest.TestCase):
         self.market.market_catalogue.event_type.id = "3"
         self.market.market_book.market_definition.market_time = 12
         self.market.flumine.markets.events = defaultdict(list)
-        m_six = mock.Mock(market_type=2, event_id=13, event_type_id="3", market_start_datetime=13)
+        m_six = mock.Mock(
+            market_type=2, event_id=13, event_type_id="3", market_start_datetime=13
+        )
         self.market.flumine.markets.events[m_six.event_id].append(m_six)
         self.assertEqual(self.market.event, {2: [m_six]})
 

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -221,6 +221,7 @@ class MarketTest(unittest.TestCase):
 
     def test_event(self):
         self.market.market_catalogue.event.id = 12
+        self.market.market_catalogue.event_type.id = "7"
         self.market.market_book.market_definition.market_time = 12
         self.market.flumine.markets.events = defaultdict(list)
         self.assertEqual(self.market.event, {})
@@ -230,12 +231,43 @@ class MarketTest(unittest.TestCase):
         m_three = mock.Mock(market_type=3, event_id=123, market_start_datetime=12)
         m_four = mock.Mock(market_type=1, event_id=12, market_start_datetime=12)
         m_five = mock.Mock(market_type=2, event_id=12, market_start_datetime=13)
+        m_six = mock.Mock(market_type=2, event_id=13, market_start_datetime=13) # different event
         self.market.flumine.markets.events[m_one.event_id].append(m_one)
         self.market.flumine.markets.events[m_two.event_id].append(m_two)
         self.market.flumine.markets.events[m_three.event_id].append(m_three)
         self.market.flumine.markets.events[m_four.event_id].append(m_four)
         self.market.flumine.markets.events[m_five.event_id].append(m_five)
+        self.market.flumine.markets.events[m_six.event_id].append(m_six)
         self.assertEqual(self.market.event, {1: [m_one, m_four], 2: [m_two]})
+
+    def test_event_filters(self):
+        self.market.market_catalogue.event.id = 12
+        self.market.market_catalogue.event_type.id = "1"
+        self.market.market_book.market_definition.market_time = 12
+        self.market.flumine.markets.events = defaultdict(list)
+        self.assertEqual(self.market.event, {})
+
+        m_one = mock.Mock(market_type=1, event_id=12, event_type_id="1", market_start_datetime=12)
+        m_two = mock.Mock(market_type=2, event_id=12, event_type_id="1", market_start_datetime=12)
+        m_three = mock.Mock(market_type=3, event_id=123, event_type_id="1", market_start_datetime=12)
+        m_four = mock.Mock(market_type=2, event_id=12, event_type_id="1", market_start_datetime=13)
+        m_five = mock.Mock(market_type=1, event_id=13, event_type_id="1", market_start_datetime=13)
+        m_six = mock.Mock(market_type=2, event_id=13, event_type_id="3", market_start_datetime=13)
+        self.market.flumine.markets.events[m_one.event_id].append(m_one)
+        self.market.flumine.markets.events[m_two.event_id].append(m_two)
+        self.market.flumine.markets.events[m_three.event_id].append(m_three)
+        self.market.flumine.markets.events[m_four.event_id].append(m_four)
+        self.market.flumine.markets.events[m_five.event_id].append(m_five)
+        self.market.flumine.markets.events[m_six.event_id].append(m_six)
+        self.assertEqual(self.market.event, {1: [m_one], 2: [m_two, m_four]})
+
+        self.market.market_catalogue.event.id = 13
+        self.market.market_catalogue.event_type.id = "3"
+        self.market.market_book.market_definition.market_time = 12
+        self.market.flumine.markets.events = defaultdict(list)
+        m_six = mock.Mock(market_type=2, event_id=13, event_type_id="3", market_start_datetime=13)
+        self.market.flumine.markets.events[m_six.event_id].append(m_six)
+        self.assertEqual(self.market.event, {2: [m_six]})
 
     def test_event_type_id_mc(self):
         mock_market_catalogue = mock.Mock()


### PR DESCRIPTION
Extend allowance of differing market_start_datetime values to golf when compiling market event property to cope with Betfair's inclination to use them as a sorting mechanism. Add tests for soccer and golf. Addresses issue #750.