### PR TITLE
Handle market catalogue missing description

### DIFF
--- a/flumine/markets/market.py
+++ b/flumine/markets/market.py
@@ -137,7 +137,7 @@ class Market:
 
     @property
     def market_type(self) -> str:
-        if self.market_catalogue:
+        if self.market_catalogue and self.market_catalogue.description:
             return self.market_catalogue.description.market_type
         elif self.market_book:
             return self.market_book.market_definition.market_type
@@ -189,7 +189,7 @@ class Market:
 
     @property
     def race_type(self) -> Optional[str]:
-        if self.market_catalogue:
+        if self.market_catalogue and self.market_catalogue.description:
             return self.market_catalogue.description.race_type
         elif self.market_book:
             return self.market_book.market_definition.race_type

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -269,6 +269,12 @@ class MarketTest(unittest.TestCase):
         self.assertEqual(
             self.market.market_type, mock_market_catalogue.description.market_type
         )
+        self.market.market_catalogue.description = None
+        mock_market_book = mock.Mock()
+        self.market.market_book = mock_market_book
+        self.assertEqual(
+            self.market.market_type, mock_market_book.market_definition.market_type
+        )
 
     def test_market_type_mb(self):
         self.market.market_catalogue = None
@@ -382,6 +388,12 @@ class MarketTest(unittest.TestCase):
         self.market.market_catalogue = mock_market_catalogue
         self.assertEqual(
             self.market.race_type, mock_market_catalogue.description.race_type
+        )
+        self.market.market_catalogue.description = None
+        mock_market_book = mock.Mock()
+        self.market.market_book = mock_market_book
+        self.assertEqual(
+            self.market.race_type, mock_market_book.market_definition.race_type
         )
 
     def test_race_type_mb(self):


### PR DESCRIPTION
This fix handles the case where a market catalogue is available but `MARKET_DESCRIPTION` was not included in the `MarketProjection`