### PR TITLE
Fix utils.get_file_md

### DIFF
--- a/flumine/utils.py
+++ b/flumine/utils.py
@@ -75,9 +75,9 @@ def get_file_md(file_dir: Union[str, tuple]) -> Optional[MarketDefinition]:
     with smart_open.open(file_dir, "r") as f:
         first_line = f.readline()
         update = json.loads(first_line)
-    if "mc" not in update or not isinstance(update["mc"], list) or not update["mc"]:
+    if "mc" not in update or not isinstance(update["mc"], list) or not update["mc"] or "marketDefinition" not in update["mc"][0]:
         return None
-    md = update["mc"][0].get("marketDefinition", {})
+    md = update["mc"][0]["marketDefinition"]
     return MarketDefinition(**md)
 
 

--- a/flumine/utils.py
+++ b/flumine/utils.py
@@ -75,7 +75,12 @@ def get_file_md(file_dir: Union[str, tuple]) -> Optional[MarketDefinition]:
     with smart_open.open(file_dir, "r") as f:
         first_line = f.readline()
         update = json.loads(first_line)
-    if "mc" not in update or not isinstance(update["mc"], list) or not update["mc"] or "marketDefinition" not in update["mc"][0]:
+    if (
+        "mc" not in update
+        or not isinstance(update["mc"], list)
+        or not update["mc"]
+        or "marketDefinition" not in update["mc"][0]
+    ):
         return None
     md = update["mc"][0]["marketDefinition"]
     return MarketDefinition(**md)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -378,6 +378,4 @@ class UtilsTest(unittest.TestCase):
 
     @mock.patch("betfairlightweight.compat.json.loads", return_value={"mc": [{}]})
     def test_get_file_md_missing_market_definition(self, mock_loads):
-        self.assertIsNone(
-            utils.get_file_md("tests/resources/PRO-1.170258213")
-        )
+        self.assertIsNone(utils.get_file_md("tests/resources/PRO-1.170258213"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -375,3 +375,9 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(
             utils.create_time(123, "12345.1310"), datetime.datetime(1970, 1, 1, 13, 10)
         )
+
+    @mock.patch("betfairlightweight.compat.json.loads", return_value={"mc": [{}]})
+    def test_get_file_md_missing_market_definition(self, mock_loads):
+        self.assertIsNone(
+            utils.get_file_md("tests/resources/PRO-1.170258213")
+        )


### PR DESCRIPTION
After changes in https://github.com/betcode-org/flumine/pull/693, `utils.get_file_md` no longer gracefully handles the case where the first line of the file contains a non-empty `mc` list where the first element is _missing a `marketDefinition` field_

On this line: https://github.com/betcode-org/flumine/blob/0241aca36f751bf1e35c5f8d7242735d2f1a5687/flumine/utils.py#L80 if the field is missing then `md` is set to a default value of an empty dictionary. However, it is not possible to then construct a `MarketDefinition` object from an empty dictionary on the following line: https://github.com/betcode-org/flumine/blob/0241aca36f751bf1e35c5f8d7242735d2f1a5687/flumine/utils.py#L81 as the following exception gets thrown:

```
TypeError: MarketDefinition.__init__() missing 22 required positional arguments: 'betDelay', 'bettingType', 'bspMarket', 'bspReconciled', 'complete', 'crossMatching', 'discountAllowed', 'eventId', 'eventTypeId', 'inPlay', 'marketBaseRate', 'marketTime', 'numberOfActiveRunners', 'numberOfWinners', 'persistenceEnabled', 'regulators', 'runnersVoidable', 'status', 'timezone', 'turnInPlayEnabled', 'version', and 'runners'
```

The fix is to guard against the `marketDefinition` field being missing and to return `None` if that is the case. A new unit test has been added which fails under the old code but passes with the added guard