### PR TITLE
Erroneous application of dead-heat rules to profit calculations

### DIFF
--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -136,7 +136,9 @@ class Blotter:
                     order.each_way_divisor = (
                         market_book.market_definition.each_way_divisor
                     )
-                    if number_of_winners > market_book.number_of_winners:
+                    if market_book.number_of_winners == 0:
+                        order.number_of_dead_heat_winners = 1
+                    elif number_of_winners > market_book.number_of_winners:
                         order.number_of_dead_heat_winners = number_of_winners
                     if (
                         order.order_type.ORDER_TYPE == ORDER_TYPE_LIMIT

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -244,6 +244,17 @@ class BlotterTest(unittest.TestCase):
             mock_market_book.market_definition.each_way_divisor,
         )
 
+    def test_process_closed_market_variable_number_of_winners(self):
+        mock_market = mock.Mock()
+        mock_market_book = mock.Mock(number_of_winners=0)
+        mock_runner1 = mock.Mock(selection_id=123, handicap=0.0, status="WINNER")
+        mock_runner2 = mock.Mock(selection_id=234, handicap=0.0, status="WINNER")
+        mock_market_book.runners = [mock_runner1, mock_runner2]
+        mock_order = mock.Mock(selection_id=123, handicap=0.0)
+        self.blotter._orders = {"12345": mock_order}
+        self.blotter.process_closed_market(mock_market, mock_market_book)
+        self.assertEqual(mock_order.number_of_dead_heat_winners, 1)
+
     def test_process_closed_market_line_range(self):
         mock_market = mock.Mock(context={"line_range_result": 119})
         mock_market_book = mock.Mock(number_of_winners=1)


### PR DESCRIPTION
There are markets for which the number of winners isn't known when the market is created (e.g. golf's make the cut market), and is determined only when the closed market is processed.

In these cases Betfair sets the number of winners to zero, and Flumine erroneously attempts to apply dead-heat rules to profit calculations and as the actual number of winners is > 0, usually in the 50-80 range. All winners are therefore treated as having dead-heated producing bizarre profit results (e.g. lay bets pretty much can't lose).

By forcing the number of dead-heats to 1 in these cases we avoid dead-heat processing where it's not appropriate.