### PR TITLE
Add max market exposure

### DIFF
--- a/flumine/controls/tradingcontrols.py
+++ b/flumine/controls/tradingcontrols.py
@@ -309,3 +309,18 @@ class StrategyExposure(BaseControl):
                         strategy.max_selection_exposure,
                     ),
                 )
+
+            # per market
+            potential_exposure = market.blotter.market_exposure(
+                strategy,
+                market.market_book,
+                order if package_type != OrderPackageType.REPLACE else None,
+            )
+            if potential_exposure > strategy.max_market_exposure:
+                return self._on_error(
+                    order,
+                    "Potential market exposure ({0:.2f}) is greater than strategy.max_market_exposure ({1})".format(
+                        potential_exposure,
+                        strategy.max_market_exposure,
+                    ),
+                )

--- a/flumine/markets/blotter.py
+++ b/flumine/markets/blotter.py
@@ -162,11 +162,16 @@ class Blotter:
 
     """ position """
 
-    def market_exposure(self, strategy, market_book) -> float:
+    def market_exposure(self, strategy, market_book, new_order=None) -> float:
         """Returns worst-case exposure for market, which is the maximum potential loss (negative),
         arising from the worst race outcome, or the minimum potential profit (positive).
+
+        Optionally include a potential new order to facilitate determining if said order would
+        exceed an exposure limit
         """
         orders = self.strategy_orders(strategy)
+        if new_order is not None:
+            orders.append(new_order)
         runners = set([order.lookup for order in orders])
         worst_possible_profits = [
             self.get_exposures(strategy, lookup) for lookup in runners

--- a/flumine/strategy/strategy.py
+++ b/flumine/strategy/strategy.py
@@ -48,6 +48,7 @@ class BaseStrategy:
         context: dict = None,
         max_selection_exposure: float = 100,
         max_order_exposure: float = 10,
+        max_market_exposure: float = 500,
         max_trade_count: int = 1e6,
         max_live_trade_count: int = 1,
         multi_order_trades: bool = False,
@@ -63,6 +64,7 @@ class BaseStrategy:
         :param context: Dictionary holding additional user specific vars
         :param max_selection_exposure: Max exposure per selection
         :param max_order_exposure: Max exposure per order
+        :param max_market_exposure: Max exposure per market
         :param max_trade_count: max total number of trades per runner
         :param max_live_trade_count: max live (with executable orders) trades per runner
         :param multi_order_trades: allow multiple live orders per trade
@@ -77,6 +79,7 @@ class BaseStrategy:
         self.context = context or {}
         self.max_selection_exposure = max_selection_exposure
         self.max_order_exposure = max_order_exposure
+        self.max_market_exposure = max_market_exposure
         self.clients = None
         self.max_trade_count = max_trade_count
         self.max_live_trade_count = max_live_trade_count

--- a/tests/test_tradingcontrols.py
+++ b/tests/test_tradingcontrols.py
@@ -576,6 +576,9 @@ class TestExecutionValidation(unittest.TestCase):
 class TestStrategyExposure(unittest.TestCase):
     def setUp(self):
         self.market = mock.Mock()
+        self.market.market_book = mock.Mock(
+            number_of_active_runners=6, number_of_winners=1
+        )
         self.market.blotter = Blotter("market_id")
         self.mock_flumine = mock.Mock()
         self.mock_flumine.markets.markets = {"market_id": self.market}
@@ -653,6 +656,7 @@ class TestStrategyExposure(unittest.TestCase):
         order1 = mock.Mock(market_id="market_id", lookup=(1, 2, 3))
         order1.trade.strategy.max_order_exposure = 10
         order1.trade.strategy.max_selection_exposure = 10
+        order1.trade.strategy.max_market_exposure = 500
         order1.order_type.ORDER_TYPE = OrderTypes.LIMIT
         order1.order_type.price_ladder_definition = "CLASSIC"
         order1.side = "BACK"
@@ -665,6 +669,7 @@ class TestStrategyExposure(unittest.TestCase):
         order2 = mock.Mock(lookup=(1, 2, 3))
         order2.trade.strategy.max_order_exposure = 10
         order2.trade.strategy.max_selection_exposure = 10
+        order2.trade.strategy.max_market_exposure = 500
         order2.trade.strategy = strategy
         order2.order_type.ORDER_TYPE = OrderTypes.LIMIT
         order2.order_type.price_ladder_definition = "CLASSIC"
@@ -859,6 +864,9 @@ class TestStrategyExposure(unittest.TestCase):
         to validate hedges the existing order, and reduces the total exposure.
         """
         mock_market = mock.Mock()
+        mock_market.market_book = mock.Mock(
+            number_of_active_runners=6, number_of_winners=1
+        )
         mock_market.blotter = Blotter(market_id="1.234")
 
         self.mock_flumine.markets.markets = {"1.234": mock_market}
@@ -866,6 +874,7 @@ class TestStrategyExposure(unittest.TestCase):
         mock_strategy = mock.Mock()
         mock_strategy.max_order_exposure = 100
         mock_strategy.max_selection_exposure = 10
+        mock_strategy.max_market_exposure = 500
 
         mock_trade = mock.Mock()
         mock_trade.strategy = mock_strategy
@@ -887,6 +896,7 @@ class TestStrategyExposure(unittest.TestCase):
         mock_order.order_type.price_ladder_definition = "CLASSIC"
         mock_order.order_type.size = 9.0
         mock_order.order_type.price = 5.0
+        mock_order.size_matched = 0.0
 
         mock_market.blotter["existing_order"] = existing_matched_order
 
@@ -905,6 +915,7 @@ class TestStrategyExposure(unittest.TestCase):
         strategy = mock.Mock()
         strategy.max_order_exposure = 10
         strategy.max_selection_exposure = 10
+        strategy.max_market_exposure = 500
 
         order1 = mock.Mock(
             market_id="market_id",


### PR DESCRIPTION
This adds a `max_market_exposure` parameter to `BaseStrategy` which is checked as part of the `StrategyExposure` control