### PR TITLE
Add get_trade(trade_id) method to blotter

### DIFF
--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -37,6 +37,15 @@ class BlotterTest(unittest.TestCase):
         self.blotter["456"] = mock_order
         self.assertEqual(self.blotter.get_order_bet_id("123"), mock_order)
 
+    def test_get_trade(self):
+        """Tests retrieving the trade by trade ID."""
+        trade_id = "abc-789"
+        self.assertIsNone(self.blotter.get_trade(trade_id))
+        mock_trade = mock.Mock(id=trade_id)
+        mock_order = mock.Mock(trade=mock_trade)
+        self.blotter["456"] = mock_order
+        self.assertEqual(self.blotter.get_trade(trade_id), mock_trade)
+
     def test_strategy_trades(self):
         mock_trade_one = mock.Mock(status=TradeStatus.PENDING, strategy=1)
         self.blotter._trades[mock_trade_one] = []


### PR DESCRIPTION
After d20e4b773db4c9c75cee4758e26f90b2583259f0, there is no way to retrieve trade's orders from the blotter through trade ID. This PR provides a method to retrieve the Trade object by the trade ID.