### PR TITLE
move lapse to after calculating any matches

### DIFF
--- a/flumine/simulation/simulatedorder.py
+++ b/flumine/simulation/simulatedorder.py
@@ -44,13 +44,6 @@ class SimulatedOrder:
                 self._bsp_reconciled = True
 
         if self.order.order_type.ORDER_TYPE == OrderTypes.LIMIT:
-            if market_book.version != self.market_version:
-                self.market_version = market_book.version  # update for next time
-                if market_book.status == "SUSPENDED":  # Material change
-                    if self.order.order_type.persistence_type == "LAPSE":
-                        self.size_lapsed += self.size_remaining
-                        return
-
             # todo estimated piq cancellations
             traded = runner_traded[1]
             if traded:
@@ -60,6 +53,13 @@ class SimulatedOrder:
                 self._process_available(
                     market_book.publish_time_epoch, runner_traded[0]
                 )
+
+            if market_book.version != self.market_version:
+                self.market_version = market_book.version  # update for next time
+                if market_book.status == "SUSPENDED":  # Material change
+                    if self.order.order_type.persistence_type == "LAPSE":
+                        self.size_lapsed += self.size_remaining
+                        return
 
     def place(
         self, order_package, market_book: MarketBook, instruction: dict, bet_id: int

--- a/tests/test_simulatedorder.py
+++ b/tests/test_simulatedorder.py
@@ -132,12 +132,15 @@ class SimulatedOrderTest(unittest.TestCase):
         mock_market_book = mock.Mock(
             bsp_reconciled=False, version=124, status="SUSPENDED"
         )
-        mock_runner_analytics = mock.Mock()
-        self.simulated(mock_market_book, mock_runner_analytics)
+        traded = {1: 2}
+        mock_runner_book = mock.Mock()
+        self.simulated(mock_market_book, (mock_runner_book, traded))
         self.assertEqual(self.simulated.size_lapsed, 2.0)
         self.assertEqual(self.simulated.size_remaining, 0.0)
         mock__process_sp.assert_not_called()
-        mock__process_traded.assert_not_called()
+        mock__process_traded.assert_called_with(
+            mock_market_book.publish_time_epoch, traded
+        )
 
     @mock.patch("flumine.simulation.simulatedorder.SimulatedOrder._get_runner")
     @mock.patch(


### PR DESCRIPTION
this is because the SP auction includes limit orders in the book therefore an order could still be matched during a suspension