### PR TITLE
Cap PIQ when book crosses past resting price

### DIFF
--- a/flumine/simulation/simulatedorder.py
+++ b/flumine/simulation/simulatedorder.py
@@ -47,6 +47,16 @@ class SimulatedOrder:
             # todo estimated piq cancellations
             traded = runner_traded[1]
             if traded:
+                # If the book has crossed our resting price (a trade strictly
+                # past our level), cap PIQ to the real liquidity now sitting
+                # at our price. Without this, a stale PIQ from placement keeps
+                # the order from filling when real liquidity at our level was
+                # cancelled or was never there - the aggressor wouldn't have
+                # reached the far level otherwise.
+                # Skip the method call when already at the front of the queue
+                # (the dominant case in real backtests).
+                if self._piq:
+                    self._cap_piq_on_book_crossing(runner_traded[0], traded)
                 self._process_traded(market_book.publish_time_epoch, traded)
 
             if config.simulation_available_prices:
@@ -453,6 +463,32 @@ class SimulatedOrder:
                 self.order.id,
                 runner.selection_id,
             )
+
+    def _cap_piq_on_book_crossing(self, runner: RunnerBook, traded: dict) -> None:
+        # If any traded price in this update is strictly past our resting
+        # price, the book has crossed us. Cap PIQ to the real liquidity now
+        # at our price: the aggressor that reached the far level must have
+        # first cleared (or found empty) the queue at our level, so anything
+        # ahead of us in PIQ should be gone.
+        if self._piq == 0:
+            return
+        price = self.order.order_type.price
+        side = self.side
+        if side == "BACK":
+            if not any(tp > price for tp in traded):
+                return
+            available = runner.ex.available_to_lay
+        else:
+            if not any(tp < price for tp in traded):
+                return
+            available = runner.ex.available_to_back
+        for avail in available:
+            if avail["price"] == price:
+                if avail["size"] < self._piq:
+                    self._piq = avail["size"]
+                return
+        # no entry at our price -> nothing real ahead of us
+        self._piq = 0
 
     def _process_traded(self, publish_time: int, traded: dict) -> None:
         # calculate matched on MarketBook update

--- a/tests/test_simulatedorder.py
+++ b/tests/test_simulatedorder.py
@@ -104,6 +104,40 @@ class SimulatedOrderTest(unittest.TestCase):
     @mock.patch(
         "flumine.simulation.simulatedorder.SimulatedOrder.take_sp", return_value=True
     )
+    def test_call_book_crossing_fills_stale_piq_back(self, _, mock__get_runner):
+        # BACK at 12, PIQ=100 stale from placement. Book has crossed past us:
+        # tv only at 13, no real liquidity at 12. The order should now fill
+        # against the half-of-tv lay-aggression appetite at the far level.
+        self.simulated._piq = 100
+        self.mock_order_type.size = 5.0
+        mock_market_book = mock.Mock(bsp_reconciled=False, version=1, status="OPEN")
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_lay = [{"price": 13, "size": 50}]
+        self.simulated(mock_market_book, (mock_runner, {13: 10}))
+        self.assertEqual(self.simulated.size_matched, 5.0)
+        self.assertEqual(self.simulated._piq, 0)
+
+    @mock.patch("flumine.simulation.simulatedorder.SimulatedOrder._get_runner")
+    @mock.patch(
+        "flumine.simulation.simulatedorder.SimulatedOrder.take_sp", return_value=True
+    )
+    def test_call_book_crossing_no_op_when_real_lqty_present(self, _, mock__get_runner):
+        # BACK at 12, PIQ=100. Far-level tv at 13 but real liquidity at 12
+        # is still 100 - the trade at 13 must be opposite-side aggression
+        # that didn't cross us. Order should NOT fill.
+        self.simulated._piq = 100
+        self.mock_order_type.size = 5.0
+        mock_market_book = mock.Mock(bsp_reconciled=False, version=1, status="OPEN")
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_lay = [{"price": 12, "size": 100}]
+        self.simulated(mock_market_book, (mock_runner, {13: 10}))
+        self.assertEqual(self.simulated.size_matched, 0)
+        self.assertEqual(self.simulated._piq, 95.0)
+
+    @mock.patch("flumine.simulation.simulatedorder.SimulatedOrder._get_runner")
+    @mock.patch(
+        "flumine.simulation.simulatedorder.SimulatedOrder.take_sp", return_value=True
+    )
     @mock.patch("flumine.simulation.simulatedorder.SimulatedOrder._process_traded")
     @mock.patch("flumine.simulation.simulatedorder.SimulatedOrder._process_sp")
     def test_call_process_sp(
@@ -1210,6 +1244,70 @@ class SimulatedOrderTest(unittest.TestCase):
         self.simulated._piq = 4.00
         self.assertEqual(self.simulated._calculate_process_traded(1234585, 20.00), 12)
         self.assertEqual(self.simulated.matched, [[1234585, 12, 2.0]])
+        self.assertEqual(self.simulated._piq, 0)
+
+    def test__cap_piq_on_book_crossing_back_no_entry(self):
+        # BACK at 12; tv at 13 (strictly past); no real lqty at 12 -> PIQ -> 0
+        self.simulated._piq = 100
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_lay = [{"price": 13, "size": 50}]
+        self.simulated._cap_piq_on_book_crossing(mock_runner, {13: 10})
+        self.assertEqual(self.simulated._piq, 0)
+
+    def test__cap_piq_on_book_crossing_back_partial(self):
+        # BACK at 12; tv at 13 (past); real lqty at 12 dropped to 30
+        self.simulated._piq = 100
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_lay = [
+            {"price": 12, "size": 30},
+            {"price": 13, "size": 50},
+        ]
+        self.simulated._cap_piq_on_book_crossing(mock_runner, {13: 10})
+        self.assertEqual(self.simulated._piq, 30)
+
+    def test__cap_piq_on_book_crossing_back_no_op_opposite_side(self):
+        # BACK at 12; tv at 13 (past); real lqty at 12 unchanged at 100
+        # (the far-level tv is opposite-side aggression that didn't cross us)
+        self.simulated._piq = 100
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_lay = [{"price": 12, "size": 100}]
+        self.simulated._cap_piq_on_book_crossing(mock_runner, {13: 10})
+        self.assertEqual(self.simulated._piq, 100)
+
+    def test__cap_piq_on_book_crossing_back_no_crossing(self):
+        # BACK at 12; tv only at 12 or below -> no crossing -> PIQ untouched
+        self.simulated._piq = 100
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_lay = [{"price": 13, "size": 50}]
+        self.simulated._cap_piq_on_book_crossing(mock_runner, {12: 10, 11: 5})
+        self.assertEqual(self.simulated._piq, 100)
+
+    def test__cap_piq_on_book_crossing_lay_no_entry(self):
+        # LAY at 12; tv at 11 (strictly past for LAY); no real lqty at 12
+        self.simulated.order.side = "LAY"
+        self.simulated._piq = 100
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_back = [{"price": 11, "size": 50}]
+        self.simulated._cap_piq_on_book_crossing(mock_runner, {11: 10})
+        self.assertEqual(self.simulated._piq, 0)
+
+    def test__cap_piq_on_book_crossing_lay_partial(self):
+        self.simulated.order.side = "LAY"
+        self.simulated._piq = 100
+        mock_runner = mock.Mock()
+        mock_runner.ex.available_to_back = [
+            {"price": 12, "size": 30},
+            {"price": 11, "size": 50},
+        ]
+        self.simulated._cap_piq_on_book_crossing(mock_runner, {11: 10})
+        self.assertEqual(self.simulated._piq, 30)
+
+    def test__cap_piq_on_book_crossing_piq_zero_short_circuit(self):
+        # Already at front of queue - nothing to do.
+        self.simulated._piq = 0
+        # Mock with no ex attribute would raise if accessed.
+        mock_runner = mock.Mock(spec=[])
+        self.simulated._cap_piq_on_book_crossing(mock_runner, {13: 10})
         self.assertEqual(self.simulated._piq, 0)
 
     def test__process_available_back(self):


### PR DESCRIPTION
Simulated orders weren't filling when the book crossed past their resting price but no real trade landed at that exact level, which happened when liquidity at the price was cancelled or never present.