### PR TITLE
Prevent infinite loop on cancel when you hit the maxtransaction limit in controls

### DIFF
--- a/flumine/controls/clientcontrols.py
+++ b/flumine/controls/clientcontrols.py
@@ -47,7 +47,7 @@ class MaxTransactionCount(BaseControl):
 
     def _validate(self, order: BaseOrder, package_type: OrderPackageType) -> None:
         self._check_hour()
-        if not self.safe:
+        if package_type != OrderPackageType.CANCEL and not self.safe:
             self._on_error(
                 order,
                 "Max Transaction Count has been reached ({0}) for current hour".format(

--- a/tests/test_clientcontrols.py
+++ b/tests/test_clientcontrols.py
@@ -72,6 +72,24 @@ class TestMaxTransactionCount(unittest.TestCase):
         self.trading_control._validate(mock_order, OrderPackageType.PLACE)
         mock_check_hour.assert_called()
 
+    @mock.patch("flumine.controls.clientcontrols.MaxTransactionCount._on_error")
+    @mock.patch("flumine.controls.clientcontrols.MaxTransactionCount._check_hour")
+    def test_validate_cancel_skips_error(self, mock_check_hour, mock_on_error):
+        self.trading_control.client.transaction_limit = -10
+        mock_order = mock.Mock()
+        self.trading_control._validate(mock_order, OrderPackageType.CANCEL)
+        mock_check_hour.assert_called()
+        mock_on_error.assert_not_called()
+
+    @mock.patch("flumine.controls.clientcontrols.MaxTransactionCount._on_error")
+    @mock.patch("flumine.controls.clientcontrols.MaxTransactionCount._check_hour")
+    def test_validate_not_safe(self, mock_check_hour, mock_on_error):
+        self.trading_control.client.transaction_limit = -10
+        mock_order = mock.Mock()
+        self.trading_control._validate(mock_order, OrderPackageType.PLACE)
+        mock_check_hour.assert_called()
+        mock_on_error.assert_called_once()
+
     @mock.patch("flumine.controls.clientcontrols.MaxTransactionCount._set_next_hour")
     def test_check_hour(self, mock_set_next_hour):
         self.trading_control._next_hour = datetime.datetime.now(datetime.timezone.utc)


### PR DESCRIPTION
If you hit the transaction limit a user has set in the client and try to cancel an order, you'll end up in an infinite loop of cancelling -> violation -> executable -> cancelling....

This patch allows cancels to still get through while not allowing any new orders to be placed and prevents the infinite cancel loop.

A successful cancel isn't a transaction so doesn't get counted, but a failed one does. We don't know which we're going to get back before we send it, so there's no way to only let through the cancels that are free.

It's slightly contradictory as this allows the MaxTransactionCount to exceed it's transaction limit and you might prefer the user handles this themselves so feel free to close if so.                                                                                                                                                                            